### PR TITLE
sc589-ezkit.dts: fix dtc warnings

### DIFF
--- a/arch/arm/dts/sc589-ezkit.dts
+++ b/arch/arm/dts/sc589-ezkit.dts
@@ -14,11 +14,15 @@
 #include "sc58x.dtsi"
 
 / {
+	#address-cells = <1>;
+	#size-cells = <1>;
 	model = "ADI sc589-ezkit";
 	compatible = "adi,sc589-ezkit", "adi,sc58x";
 };
 
 &i2c2 {
+	#address-cells = <1>;
+	#size-cells = <0>;
 	gpio_expander1: mcp23017@21 {
 		compatible = "microchip,mcp23017";
 		reg = <0x21>;


### PR DESCRIPTION
The dtc throws the following warnings when compiling the dts for the sc589-ezkit (for both the SPL and U-Boot proper):

	arch/arm/dts/sc589-ezkit.dtb: Warning (reg_format): /soc/i2c2@31001600/mcp23017@21:reg: property has invalid length (4 bytes) (#address-cells == 2, #size-cells == 1)
	arch/arm/dts/sc589-ezkit.dtb: Warning (reg_format): /soc/i2c2@31001600/mcp23017@22:reg: property has invalid length (4 bytes) (#address-cells == 2, #size-cells == 1)
	arch/arm/dts/sc589-ezkit.dtb: Warning (ranges_format): /soc:ranges: empty "ranges" property but its #address-cells (1) differs from / (2)
	arch/arm/dts/sc589-ezkit.dtb: Warning (avoid_default_addr_size): /soc: Relying on default #address-cells value
	arch/arm/dts/sc589-ezkit.dtb: Warning (avoid_default_addr_size): /soc: Relying on default #size-cells value
	arch/arm/dts/sc589-ezkit.dtb: Warning (avoid_default_addr_size): /soc/i2c2@31001600/mcp23017@21: Relying on default #address-cells value
	arch/arm/dts/sc589-ezkit.dtb: Warning (avoid_default_addr_size): /soc/i2c2@31001600/mcp23017@21: Relying on default #size-cells value
	arch/arm/dts/sc589-ezkit.dtb: Warning (avoid_default_addr_size): /soc/i2c2@31001600/mcp23017@22: Relying on default #address-cells value
	arch/arm/dts/sc589-ezkit.dtb: Warning (avoid_default_addr_size): /soc/i2c2@31001600/mcp23017@22: Relying on default #size-cells value

The fixes involve explicitly setting the #address-cells and #size-cells values.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>