### PR TITLE
Make the SC589-MINI's SPI Flash boot RFS 'minimal' instead of 'tiny'

### DIFF
--- a/include/configs/sc589-mini.h
+++ b/include/configs/sc589-mini.h
@@ -98,7 +98,7 @@
 #define ADI_UBOOT_OFFSET "0x20000"
 #define ADI_IMG_OFFSET   "0xE0000"
 #define ADI_RFS_OFFSET   "0x6E0000"
-#define ADI_JFFS2_FILE   "tiny" //use the adsp-sc5xx-tiny image
+#define ADI_JFFS2_FILE   "minimal" //use the adsp-sc5xx-minimal image
 
 #include <configs/sc_adi_common.h>
 


### PR DESCRIPTION
The MINI version that we support (>= 1.5) comes equipped with a 64 MB flash chip, whereas the rest of the SC58* & SC573 EZKIT's come with 16 MB. This means that the MINI can hold the minimal image in the flash, and is not forced to use the tiny.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
