### PR TITLE
idcode: Adding support for parsing idcode register

### DIFF
--- a/arch/arm/include/asm/arch-adi/sc5xx/idcode.h
+++ b/arch/arm/include/asm/arch-adi/sc5xx/idcode.h
@@ -1,0 +1,24 @@
+#define TAPC_IDCODE	(uint8_t*) 0x31130000  /* Silicon Revision */ 
+
+#define BITM_SI_REVID	0xF0000000 /* Revision ID */
+#define BITM_JTAGID	0x0FFFF000 /* JTAG ID */
+#define BITM_MNFID	0x00000FFE /* Manufacturer ID */
+#define BITM_LSB	0x00000001 /* IDCODE LSB */
+
+#define ADI_MNFID	0x65
+#define ADI_LSB		0x01
+
+#define GRFN_SC58X_JTAGID   0x2808	// Device ID
+#define GRFN_SC58X_SI_REVID_0_0    0x00    // Rev 0.0 silicon for SC58X     (IDCODE value is 0x028080CB)
+#define GRFN_SC58X_SI_REVID_0_1    0x01    // Rev 0.1 silicon for SC58X     (IDCODE value is 0x128080CB)
+#define GRFN_SC58X_SI_REVID_1_0    0x02    // Rev 1.0 silicon for SC58X     (IDCODE value is 0x228080CB)
+#define GRFN_SC58X_SI_REVID_1_2    0x04    // Rev 1.2 silicon for SC58X     (IDCODE value is 0x428080CB)
+
+#define GRFN_SC59X_JTAGID	0x280B	// Device ID
+#define GRFN_SC59X_SI_REVID_0_0	0x00 	// Rev 0.0 Silicon for SC59X
+
+enum adsp_family { 
+       unknown,	
+	sc58x,  
+	sc59x
+};

--- a/arch/arm/mach-sc5xx/soc.c
+++ b/arch/arm/mach-sc5xx/soc.c
@@ -15,6 +15,7 @@
 #include <cpu_func.h>
 
 #include <asm/arch-adi/sc5xx/soc.h>
+#include <asm/arch-adi/sc5xx/idcode.h>
 
 void reset_cpu(void)
 {
@@ -45,6 +46,98 @@ int arch_cpu_init(void)
 	return 0;
 }
 
+
+
+
+enum adsp_family get_device_type(u32 device_type)
+{
+	if(GRFN_SC58X_JTAGID == device_type)
+		return sc58x;
+	else if(GRFN_SC59X_JTAGID == device_type)
+		return sc59x;
+	else
+		log_debug("unknown [%04x]\n",device_type);
+	
+	return unknown;
+}
+
+/* 
+* Revision ID is similarly coded for different boards
+* and as a result, is currently set to be shared by different 
+* devices
+*
+* Since the actual silicon version is a floating point, the 
+* information is stored as an 8 bit number in decimal. The parsed 
+* revision ID can be obtained by dividing the returned value by 100.
+*
+* Eg: The revision 1.2 is returned as 120
+* */
+u8 get_si_version(u32 si_version)
+{
+	if (GRFN_SC58X_SI_REVID_0_0 == si_version)
+		return 0;
+	else if (GRFN_SC58X_SI_REVID_0_1 == si_version)
+		return 10;
+	else if (GRFN_SC58X_SI_REVID_1_0 == si_version)
+		return 100;
+	else if (GRFN_SC58X_SI_REVID_1_2 == si_version)
+		return 120;
+	else
+		log_debug("x.x [%01x]\n",si_version);
+
+	return 0xFF;
+}
+
+int auth_reading(u32 mfid,u32 lsb)
+{
+	if ((mfid != ADI_MNFID) || (lsb != ADI_LSB)) {
+		log_debug("WARNING: UNEXPECTED VALUES IN ID CODE\n");
+		log_debug("[MNFID]EXPECTED: %02x, GOT: %02x\n", ADI_MNFID, mfid);
+		log_debug("[LSB]EXPECTED: %02x, GOT: %02x\n", ADI_LSB, lsb);
+		log_debug("ABORTING AUTO DETECTION\n");
+		return -1;
+	} else {
+		printf("[Detected] ADI Device\n");
+	}
+	return 0;
+}
+
+void read_tapc_idcode(void)
+{
+	u32 id = *(TAPC_IDCODE);
+	
+	u32 si_version = ((id & BITM_SI_REVID) & BITM_SI_REVID) >> 28;
+	u32 device_type = ((id & BITM_JTAGID) & BITM_JTAGID) >> 12;
+	u32 mfid = ((id & BITM_MNFID) & BITM_MNFID) >> 1;
+	u32 lsb = (id & BITM_LSB) & BITM_LSB;
+
+	enum adsp_family family_type;
+	u8 parsed_si_version;
+
+	if(!auth_reading(mfid,lsb)) {
+		parsed_si_version = get_si_version(si_version);
+		family_type = get_device_type(device_type);
+	}else{
+		log_debug("SKIPPING IDCODE REGISTER PARSING, DEVICE NOT RECOGNISED\n");
+	}
+
+
+	/* Only append details which have been detected correctly */
+	printf("[Detected] ");
+	if(family_type != unknown) {
+		if(family_type == sc58x)
+			printf("family: adsp-sc58x ");
+		if(family_type == sc59x)
+			printf("family: adsp-sc59x ");
+	} 
+
+	if(parsed_si_version != 0xFF) {
+		printf("silicon version: %d.%d\n",parsed_si_version/100,parsed_si_version%100);
+	}
+
+}
+
+
 void print_cpu_id(void)
 {
 #ifndef CONFIG_ARM64
@@ -52,16 +145,19 @@ void print_cpu_id(void)
 
 	__asm__ __volatile__("mrc p15, 0, %0, c0, c0, 0" : "=r"(cpuid));
 
-	printf("Detected Revision: %d.%d\n", cpuid & 0xf00000 >> 20, cpuid & 0xf);
+	printf("[Detected] Revision: %d.%d\n", cpuid & 0xf00000 >> 20, cpuid & 0xf);
 #endif
 }
 
 int print_cpuinfo(void)
 {
+
 	printf("CPU:   ADSP %s (%s boot)\n",
 	       CONFIG_LDR_CPU,  get_sc_boot_mode(CONFIG_SC_BOOT_MODE));
 
 	print_cpu_id();
+	log_debug("Reading on-board IDCODE register\n");
+	read_tapc_idcode();
 
 	return 0;
 }


### PR DESCRIPTION
Allows reading device specifications at boot time

Since the TCP_IDCODE register is a common feature between multiple devices regardless of processor, it will be attempted to be read for all boards. 
u-boot accesses a hardcoded physical address and reads 4B of data. This is then split between various fields (as follows):
![image](https://github.com/analogdevicesinc/lnxdsp-u-boot/assets/141642367/e7fe859b-c033-4c9d-913e-c7e9a92c5318)

u-boot then conducts some minimal checks (matches the manufacturer id and lsb) to confirm that the value being read is valid and then proceeds to display the obtained information.

Tested on sc584 and sc598. 
NOTE: Both models however seemed to have 0x0 for JTAG ID and Silicon revision number but passed the preliminary checks(as mentioned above).