### PR TITLE
Adding developer mode for all adsp-sc5xx boards

### DIFF
--- a/arch/arm/mach-sc5xx/Kconfig
+++ b/arch/arm/mach-sc5xx/Kconfig
@@ -191,6 +191,12 @@ config ADI_FALCON
 	help
 		Enable Falcon Boot Mode Support
 
+config ADI_DEVELOPER
+	bool "Enable Development Support"
+	default n
+	help
+		Allows changing bootmode via JTAG
+
 config ADI_SPL_FORCE_BMODE
 	int "Force the SPL to use this BMODE device during next boot stage"
 	default 0


### PR DESCRIPTION
This allows switching between different boot methods by utilizing JTAG

In order to change the bootmode as required:

1. Define CONFIG_ADI_DEVELOPER - this can be done by enabling CONFIG_ADI_DEVELOPER (it can be defined manually inside adi arch/arm/mach-sc5xx/spl.c)
2. Turn the dial to bootmode 0 and reset the board
3. load the SPL via gdb, which should now give some additional print statements
 ```
U-Boot SPL 2023.04 (Nov 09 2023 - 10:39:28 +0000)
ADI Boot Mode: 0x0 (JTAG/BOOTROM)
Entering Developer Mode...
Please enter a bootmode at 0x82000000 via JTAG:
[1]     JTAG/BOOTROM
[2]     QSPI Master
[3]     QSPI Slave
[4]     UART
[5]     LP0 Slave
[6]     OSPI
SPL execution has completed.  Please load U-Boot Proper via JTAG
```
Note that the address listed above is arbitrary and was chosen since Uboot was already using $loadaddr at the same location.
4. Now on GDB, stop the program and write to the memory location using the following command:
`set {int}0x82000000 = <bootmode>`
5. load the SPL again and it will boot into the requested mode (the following shows boot into QSPI Master):
```
U-Boot SPL 2023.04 (Nov 09 2023 - 10:39:28 +0000)
ADI Boot Mode: 0x0 (JTAG/BOOTROM)
Entering Developer Mode...
Booting into QSPI Master
Trying to boot from BOOTROM


U-Boot 2023.04 (Nov 09 2023 - 10:39:28 +0000)

CPU:   ADSP ADSP-SC594-0.0 (spi slave boot)
Detected Revision: 1.1
Model: ADI sc594-som-ezkit
DRAM:  992 MiB
Core:  120 devices, 19 uclasses, devicetree: embed
MMC:
Loading Environment from SPIFlash... Read ID via 1x SPI: 9d 5a 19
SF: Detected is25lx256 with page size 256 Bytes, erase size 128 KiB, total 32 MiB
OK
In:    serial@0x31003000
Out:   serial@0x31003000
Err:   serial@0x31003000
Net:   eth0: eth0
Error: eth1 address not set.

Hit any key to stop autoboot:  6
```