### PR TITLE
sc58x: correct mmc clock assignment in device tree

### DIFF
--- a/arch/arm/dts/sc58x.dtsi
+++ b/arch/arm/dts/sc58x.dtsi
@@ -127,7 +127,7 @@
 };
 
 &mmc{
-	clocks = <&dummy>, <&clk ADSP_SC58X_CLK_CGU0_SCLK0>;
+	clocks = <&clk ADSP_SC58X_CLK_CGU0_SCLK0>, <&clk ADSP_SC58X_CLK_SDIO>;
 };
 
 &i2c0{


### PR DESCRIPTION
Previously the incorrect clock was listed, resulting in a larger-than-necessary divisor being selected, leading to reduced mmc performance. This changes the clock configuration to match the configuration listed in the linux device tree and improves measured read/write speeds
