### PR TITLE
board: adi: 594: Adjust SPI bootROM baud to 41.6MHz

### DIFF
--- a/board/adi/common-sc594-som/sc594-som-spl.c
+++ b/board/adi/common-sc594-som/sc594-som-spl.c
@@ -14,8 +14,10 @@
 const struct adi_boot_args adi_rom_boot_args[] = {
 	// JTAG/no boot
 	[0] = {0, 0, 0},
-	// SPI master, used for qspi as well
-	[1] = {0x60040000, 0x00040000, 0x00000207},
+	/* SPI master, used for qspi as well
+	 * Baud 2, 1 dummy cycle, bcode 2, 3 byte addr, SPI2, memory map
+	 */
+	[1] = {0x60040000, 0x00040000, 0x20620247},
 	// SPI slave
 	[2] = {0, 0, 0x00000212},
 	// UART slave


### PR DESCRIPTION
With the SC594 SOM attached to the ezkit carrier board, the default SPI2 boot baud for bcode 2 seems to be too fast, generating errors. Bcode 2 works when the carrier board is disconnected.

The default is 125MHz / (1 + 1) = 62.5MHz. Bcode 0 or 1 is 7.8MHz, which is painfully slow. This change uses bcode 2 as the base configuration, but then adjusts the clock to 125MHz / (2 + 1) = 41.6MHz.