### PR TITLE
Fix when SC598 can't boot from bootmode=1

### DIFF
--- a/board/adi/common-sc598-som/sc598-som-spl.c
+++ b/board/adi/common-sc598-som/sc598-som-spl.c
@@ -18,7 +18,7 @@ const struct adi_boot_args adi_rom_boot_args[] = {
 	// JTAG/no boot
 	[0] = {0, 0, 0},
 	// SPI master, used for qspi as well
-	[1] = {0x60040000, 0x00040000, 0x00000207},
+	[1] = {0x60040000, 0x00040000, 0x20620247},
 	// SPI slave
 	[2] = {0, 0, 0x00000212},
 	// UART slave


### PR DESCRIPTION
Some of SC598 SoM boards have issues booting when bootmode is set to 1
