### PR TITLE
sc5xx: Make the correct .ldr for U-Boot proper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2035,7 +2035,7 @@ RENAME_FILES += u-boot u-boot.bin u-boot.ldr u-boot.srec u-boot.lds u-boot.map
 
 u-boot-$(CONFIG_SYS_BOARD).ldr: $(INPUTS-y)
 	@$(foreach file,$(RENAME_FILES),\
-		mv $(file) $(subst u-boot, u-boot-$(CONFIG_SYS_BOARD), $(file));)
+		cp $(file) $(subst u-boot, u-boot-$(CONFIG_SYS_BOARD), $(file));)
 endif
 spl/u-boot-spl.bin: spl/u-boot-spl
 	@:

--- a/scripts/Makefile.spl
+++ b/scripts/Makefile.spl
@@ -381,14 +381,14 @@ $(obj)/$(BOARD)-spl.bin: $(obj)/u-boot-spl.bin
 	$(objtree)/tools/mkexynosspl) $(VAR_SIZE_PARAM) $< $@
 endif
 
-u-boot-$(CONFIG_SYS_BOARD).ldr: u-boot.ldr u-boot
-		cp u-boot.ldr u-boot-spl-$(CONFIG_SYS_BOARD).ldr
-		cp spl/u-boot-spl u-boot-spl-$(CONFIG_SYS_BOARD).elf
-		cp u-boot u-boot-proper-$(CONFIG_SYS_BOARD).elf
+u-boot-$(CONFIG_SYS_BOARD).ldr: u-boot $(obj)/u-boot-spl $(obj)/u-boot-spl.ldr
+		cp u-boot u-boot-$(CONFIG_SYS_BOARD).elf
+		cp $(obj)/u-boot-spl u-boot-spl-$(CONFIG_SYS_BOARD).elf
+		cp $(obj)/u-boot-spl.ldr u-boot-spl-$(CONFIG_SYS_BOARD).ldr
 
-u-boot.ldr:	$(obj)/u-boot-spl
+$(obj)/u-boot-spl.ldr:	$(obj)/u-boot-spl
 		$(CREATE_LDR_ENV)
-		$(LDR) -T $(CONFIG_LDR_CPU) -c $@ spl/u-boot-spl $(LDR_FLAGS)
+		$(LDR) -T $(CONFIG_LDR_CPU) -c $@ $< $(LDR_FLAGS)
 		$(BOARD_SIZE_CHECK)
 
 quiet_cmd_objcopy = OBJCOPY $@


### PR DESCRIPTION
## The Issue

Before the changes in this PR, `Make` wasn't handling correctly the generation of both spl and proper .ldr files.
Both were based on _u-boot.ldr_ filename and the proper .ldr was overwritten by the spl .ldr.

![image](https://github.com/analogdevicesinc/lnxdsp-u-boot/assets/6116642/a4242c38-5b83-4f9f-8fa7-1cc0c5d9c7b6)

## How to Reproduce

I reproduced the issue on `main` with those commands:
```sh
make clean
make sc584-ezkit_defconfig
CROSS_COMPILE=/opt/analog/cces/2.9.4/ARM/arm-none-eabi/bin/arm-none-eabi- make
```

Then I checked the generated .ldr files - the sizes are the same.

## Outcome of Changes

This PR fixes this issue by generating _u-boot-spl.ldr_ under the `spl/` directory. Now the sizes of the .ldr files make more sense:

![image](https://github.com/analogdevicesinc/lnxdsp-u-boot/assets/6116642/d9752dd4-0515-41e8-8a9b-fe5633a1dd80)

Tested on SC584-EZKIT, REV 2.4. The loader files can be written and loaded from the SPI flash.

![image](https://github.com/analogdevicesinc/lnxdsp-u-boot/assets/6116642/2ab15cf0-1ca6-4659-9c17-f3ef31b63b97)

Also, verified that `make` command can be run repeatidly without failing.


Also tested against Yocto 3.1.1 release and it doesn't interfere with `adi-u-boot` and `adsp-boot` recipes.