### PR TITLE
SC594: Hotfix for SC594 L3 DDR memory overlap

### DIFF
--- a/include/configs/sc594-som.h
+++ b/include/configs/sc594-som.h
@@ -18,8 +18,8 @@
 /*
  * Processor Settings
  */
-#define CONFIG_LOADADDR	0x82000000
-#define CONFIG_DTBLOADADDR	"0x84000000"
+#define CONFIG_LOADADDR	0xA2000000
+#define CONFIG_DTBLOADADDR	"0xA4000000"
 #ifdef CONFIG_ADI_CARRIER_SOMCRR_EZLITE
 #define CONFIG_MACH_TYPE MACH_TYPE_SC594_SOM_EZLITE;
 #else
@@ -47,8 +47,8 @@
 #define CONFIG_SYS_SPI_ARGS_OFFS   0xA0000    // This is where the DTB should be stored
 #define CONFIG_SYS_SPI_ARGS_SIZE   0x10000    // Max size of the DTB
 #define CONFIG_SYS_SPI_KERNEL_OFFS 0x120000   // Where the kernel Image or FIT should be stored
-#define CONFIG_SYS_SPL_ARGS_ADDR   0x80000000 // Where to load the DTB into RAM
-#define CONFIG_SYS_LOAD_ADDR       0x82000000 // Where to load the Image into RAM
+#define CONFIG_SYS_SPL_ARGS_ADDR   0xA0000000 // Where to load the DTB into RAM
+#define CONFIG_SYS_LOAD_ADDR       0xA2000000 // Where to load the Image into RAM
 #define CONFIG_SYS_SPI_KERNEL_SKIP_HEADER
 #endif
 
@@ -59,8 +59,8 @@
 #define MEM_ISSI_8Gb_DDR3_800MHZ
 #define MEM_DMC0
 
-#define CONFIG_SYS_SDRAM_BASE	0x82000000
-#define CONFIG_SYS_SDRAM_SIZE	0x3E000000
+#define CONFIG_SYS_SDRAM_BASE	0xA0000000
+#define CONFIG_SYS_SDRAM_SIZE	0x20000000
 #define CONFIG_SYS_TEXT_BASE	0xB2200000
 #ifndef CONFIG_SPL_BUILD
 #define CONFIG_SYS_LOAD_ADDR	0x0
@@ -95,10 +95,10 @@
 /*
  * Misc Settings
  */
-#define ADI_LINUX_MEMSIZE	"992M"
+#define ADI_LINUX_MEMSIZE	"512M"
 
 #define CONFIG_BOOTCOMMAND	"run ospiboot"
-#define INITRAMADDR "0x85000000"
+#define INITRAMADDR "0xA8000000"
 
 #define ADI_ENV_SETTINGS \
 	"usb_pgood_delay=1000\0" \

--- a/include/configs/sc_adi_common.h
+++ b/include/configs/sc_adi_common.h
@@ -62,10 +62,19 @@
 
 #define ADI_MMC_BOOTCMD "run mmcargs; " ADI_BOOT ""
 
+
+//only applicable for SC594
+#if defined CONFIG_SC59X && !CONFIG_SC59X_64
+#define ADI_MEM_SIZE	"mem=512M "
+#else
+#define ADI_MEM_SIZE	""
+#endif
+
 #define ADI_BOOTARGS_CONSOLE \
 		ADI_EARLYPRINTK \
 		"console=ttySC" __stringify(CONFIG_UART_CONSOLE) "," \
-						__stringify(CONFIG_BAUDRATE) " " \
+				__stringify(CONFIG_BAUDRATE) " " \
+				ADI_MEM_SIZE " " \
 		"vmalloc=512M "
 
 #define ADI_BOOTARGS_MMC \


### PR DESCRIPTION
Resizing accessible memory range for ARM on sc594 such that it does not overlap with SHARC allocated address space

