### PR TITLE
Fix `saveenv` in U-Boot, on SC573.

### DIFF
--- a/include/configs/sc_adi_common.h
+++ b/include/configs/sc_adi_common.h
@@ -360,9 +360,9 @@
  */
 //TODO: Delete this whole block
 #if !(defined(CONFIG_SC59X) || defined(CONFIG_SC58X) || defined(CONFIG_SC59X_64))
-	#define CONFIG_ENV_OFFSET       0x10000
-	#define CONFIG_ENV_SIZE         0x2000
-	#define CONFIG_ENV_SECT_SIZE    0x10000
+	// #define CONFIG_ENV_OFFSET       0x10000
+	// #define CONFIG_ENV_SIZE         0x2000
+	// #define CONFIG_ENV_SECT_SIZE    0x10000
 	/* We need envcrc to embed the env into LDRs */
 	#ifdef CONFIG_ENV_IS_EMBEDDED_IN_LDR
 	# define CONFIG_BUILD_ENVCRC


### PR DESCRIPTION
`saveenv` was writing to the wrong place in SPI, so was overwriting U-Boot itself and rendering the system unbootable, requiring a reflash from the debug environment.

The error was simply that the offset for the env specified in the defconfig was overwritten in `sc_adi_common.h`. Removed the lines that overwrote the relevant config options and it now works fine.

Note that currently, `env load` doesn't seem to be enabled so while `saveenv` works, it is effectively useless. Currently working on enabling that, and will push it to this branch once it's done.
Edit: after discussion with vas, `env load` being disabled is expected behaviour, however the environment should still be loaded on startup, which it isn't. Going to put this up for merging for now, and will hopefully make a new PR once that is fixed.
