### PR TITLE
Add CONFIG_SET_SHARC_IDLE, to force SHARC's idle register on boot.

### DIFF
--- a/arch/arm/include/asm/arch-adi/sc5xx/sc5xx_sharc_idle.h
+++ b/arch/arm/include/asm/arch-adi/sc5xx/sc5xx_sharc_idle.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * (C) Copyright 2024 - Analog Devices, Inc.
+ */
+
+#ifndef _SC5XX_SHARC_IDLE_H_
+#define _SC5XX_SHARC_IDLE_H_
+
+#define ADI_RCU_REG_BASE 0x3108c000
+
+/* Register offsets */
+#define ADI_RCU_REG_MSG				0x6c
+#define ADI_RCU_REG_MSG_SET			0x70
+#define ADI_RCU_REG_MSG_CLR			0x74
+
+/* Bit values for the RCU0_MSG register */
+#define RCU0_MSG_C0IDLE			0x00000100		/* Core 0 Idle */
+#define RCU0_MSG_C1IDLE			0x00000200		/* Core 1 Idle */
+#define RCU0_MSG_C2IDLE			0x00000400		/* Core 2 Idle */
+
+#ifdef CONFIG_SET_SHARC_IDLE
+/**
+ * set_sharc_cores_idle() - set the idle flag in RCU_MSG for the SHARC cores. 
+ * 
+ * Returns: 0 on success, an error code otherwise.
+ */
+int set_sharc_cores_idle(void);
+#endif // CONFIG_SET_SHARC_IDLE
+
+#endif // _SC5XX_SHARC_IDLE_H_

--- a/arch/arm/mach-sc5xx/Kconfig
+++ b/arch/arm/mach-sc5xx/Kconfig
@@ -204,6 +204,10 @@ config ADI_SPL_FORCE_BMODE
 	  5 = QSPI -> OSPI
 	  6 = QSPI -> eMMC
 
+config SET_SHARC_IDLE
+	bool "Force the SHARC cores' idle register to be set during boot"
+	default n
+
 config CLKIN_HZ
 	int "CLKIN_HZ"
 	default 25000000

--- a/arch/arm/mach-sc5xx/Makefile
+++ b/arch/arm/mach-sc5xx/Makefile
@@ -15,3 +15,4 @@ obj-y += sc59x/sc59x-shared.o
 endif
 
 obj-$(CONFIG_SPL_BUILD) += spl.o
+obj-$(CONFIG_SPL_BUILD) += sc5xx_sharc_idle.o

--- a/arch/arm/mach-sc5xx/sc5xx_sharc_idle.c
+++ b/arch/arm/mach-sc5xx/sc5xx_sharc_idle.c
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * (C) Copyright 2024 - Analog Devices, Inc.
+ */
+
+#include <asm/io.h>
+#include <asm/arch-adi/sc5xx/sc5xx_sharc_idle.h>
+#include <log.h>
+
+#ifdef CONFIG_SET_SHARC_IDLE
+static int sharc_set_idle(unsigned int coreid) {
+	writew(RCU0_MSG_C0IDLE << coreid, ADI_RCU_REG_BASE + ADI_RCU_REG_MSG_SET);
+
+	return 0;
+}
+
+extern int set_sharc_cores_idle(void) {
+    debug("Setting the SHARC cores to IDLE...\n");
+
+	int ret;
+
+    for (int c = 1; c <= 2; c++) {
+        ret = sharc_set_idle(c);
+        if (ret) {
+            printf("Error setting SHARC Core%d idle.\n", c - 1);
+            return ret;
+        }
+    }
+
+	return 0;
+}
+#endif // CONFIG_SET_SHARC_IDLE

--- a/arch/arm/mach-sc5xx/spl.c
+++ b/arch/arm/mach-sc5xx/spl.c
@@ -224,6 +224,12 @@ void board_init_f(ulong dummy)
 		panic("spl_early_init() failed\n");
 
 	preloader_console_init();
+
+#ifdef CONFIG_SET_SHARC_IDLE
+	ret = set_sharc_cores_idle();
+	if (ret)
+		printf("Warn: failed to set SHARC cores idle (%d)\n", ret);
+#endif
 }
 
 #ifdef CONFIG_ADI_FALCON


### PR DESCRIPTION
Add config option `CONFIG_SET_SHARC_IDLE`, which will, during SPL, force the SHARC cores on ADSP-SC5xx processors' idle registers to be set. 

During boot with OpenOCD, these registers are erroneously cleared, which causes the Linux driver to fail to probe them. Setting the idle register prevents this.

To enable, set `CONFIG_SET_SHARC_IDLE=y` in the defconfig.