### PR TITLE
board: adi: sc5xx: fix incorrect gpio polarities

### DIFF
--- a/arch/arm/dts/sc573-ezkit.dts
+++ b/arch/arm/dts/sc573-ezkit.dts
@@ -28,17 +28,17 @@
 
 		eeprom {
 			gpio-hog;
-			gpios = <0 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~eeprom-en";
+			gpios = <0 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "eeprom-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		uart0-flow-en {
 			gpio-hog;
-			gpios = <1 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~uart0-flow-en";
+			gpios = <1 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "uart0-flow-en";
 			u-boot,dm-pre-reloc;
 		};
 
@@ -52,73 +52,73 @@
 
 		can0 {
 			gpio-hog;
-			gpios = <6 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~can0-en";
+			gpios = <6 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "can0-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		can1 {
 			gpio-hog;
-			gpios = <7 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~can1-en";
+			gpios = <7 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "can1-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		adau1962 {
 			gpio-hog;
-			gpios = <8 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~adau1962-en";
+			gpios = <8 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "adau1962-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		adau1979 {
 			gpio-hog;
-			gpios = <9 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~adau1979-en";
+			gpios = <9 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "adau1979-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		sd-wp-en {
 			gpio-hog;
-			gpios = <11 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~sd-wp-en";
+			gpios = <11 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "sd-wp-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		spi2flash-cs {
 			gpio-hog;
-			gpios = <12 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~spi2flash-cs";
+			gpios = <12 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "spi2flash-cs";
 			u-boot,dm-pre-reloc;
 		};
 
 		spi2d2-d3 {
 			gpio-hog;
-			gpios = <13 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~spi2d2-d3-en";
+			gpios = <13 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "spi2d2-d3-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		spdif-opt {
 			gpio-hog;
-			gpios = <14 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~spdif-optical-en";
+			gpios = <14 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "spdif-optical-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		spdif-dig {
 			gpio-hog;
-			gpios = <15 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~spdif-digital-en";
+			gpios = <15 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "spdif-digital-en";
 			u-boot,dm-pre-reloc;
 		};
 	};
@@ -132,97 +132,97 @@
 
 		pushbutton3 {
 			gpio-hog;
-			gpios = <0 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~pushbutton3-en";
+			gpios = <0 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "pushbutton3-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		pushbutton2 {
 			gpio-hog;
-			gpios = <1 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~pushbutton2-en";
+			gpios = <1 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "pushbutton2-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		pushbutton1 {
 			gpio-hog;
-			gpios = <2 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~pushbutton1-en";
+			gpios = <2 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "pushbutton1-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		leds {
 			gpio-hog;
-			gpios = <3 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~leds-en";
+			gpios = <3 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "leds-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		flg0 {
 			gpio-hog;
-			gpios = <4 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~flg0_loop";
+			gpios = <4 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "flg0_loop";
 			u-boot,dm-pre-reloc;
 		};
 
 		flg1 {
 			gpio-hog;
-			gpios = <5 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~flg1_loop";
+			gpios = <5 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "flg1_loop";
 			u-boot,dm-pre-reloc;
 		};
 
 		flg2 {
 			gpio-hog;
-			gpios = <6 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~flg2_loop";
+			gpios = <6 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "flg2_loop";
 			u-boot,dm-pre-reloc;
 		};
 
 		flg3 {
 			gpio-hog;
-			gpios = <7 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~flg3_loop";
+			gpios = <7 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "flg3_loop";
 			u-boot,dm-pre-reloc;
 		};
 
 		adau1977 {
 			gpio-hog;
-			gpios = <8 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~adau1977_en";
+			gpios = <8 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "adau1977_en";
 			u-boot,dm-pre-reloc;
 		};
 
 		adau1977_fault_rst {
 			gpio-hog;
-			gpios = <9 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~adau1977_fault_rst_en";
+			gpios = <9 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "adau1977_fault_rst_en";
 			u-boot,dm-pre-reloc;
 		};
 
 		thumbwheel {
 			gpio-hog;
-			gpios = <10 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~thumbwheel_oe";
+			gpios = <10 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "thumbwheel_oe";
 			u-boot,dm-pre-reloc;
 		};
 
 		engine_rpm {
 			gpio-hog;
-			gpios = <11 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~engine_rpm_oe";
+			gpios = <11 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "engine_rpm_oe";
 			u-boot,dm-pre-reloc;
 		};
 	};

--- a/arch/arm/dts/sc584-ezkit.dts
+++ b/arch/arm/dts/sc584-ezkit.dts
@@ -28,25 +28,25 @@
 
 		eeprom {
 			gpio-hog;
-			gpios = <0 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~eeprom-en";
+			gpios = <0 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "eeprom-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		uart0-flow-en {
 			gpio-hog;
-			gpios = <1 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~uart0-flow-en";
+			gpios = <1 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "uart0-flow-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		uart0-en {
 			gpio-hog;
-			gpios = <2 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~uart0-en";
+			gpios = <2 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "uart0-en";
 			u-boot,dm-pre-reloc;
 		};
 
@@ -60,33 +60,33 @@
 
 		can0 {
 			gpio-hog;
-			gpios = <6 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~can0-en";
+			gpios = <6 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "can0-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		can1 {
 			gpio-hog;
-			gpios = <7 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~can1-en";
+			gpios = <7 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "can1-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		adau1962 {
 			gpio-hog;
-			gpios = <8 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~adau1962-en";
+			gpios = <8 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "adau1962-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		adau1979 {
 			gpio-hog;
-			gpios = <9 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~adau1979-en";
+			gpios = <9 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "adau1979-en";
 			u-boot,dm-pre-reloc;
 		};
 
@@ -100,33 +100,33 @@
 
 		spi2d2-d3 {
 			gpio-hog;
-			gpios = <12 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~spi2d2-d3-en";
+			gpios = <12 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "spi2d2-d3-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		spi2flash-cs {
 			gpio-hog;
-			gpios = <13 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~spi2flash-cs";
+			gpios = <13 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "spi2flash-cs";
 			u-boot,dm-pre-reloc;
 		};
 
 		spdif-opt {
 			gpio-hog;
-			gpios = <14 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~spdif-optical-en";
+			gpios = <14 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "spdif-optical-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		spdif-dig {
 			gpio-hog;
-			gpios = <15 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~spdif-digital-en";
+			gpios = <15 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "spdif-digital-en";
 			u-boot,dm-pre-reloc;
 		};
 	};
@@ -140,97 +140,97 @@
 
 		pushbutton3 {
 			gpio-hog;
-			gpios = <0 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~pushbutton3-en";
+			gpios = <0 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "pushbutton3-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		pushbutton2 {
 			gpio-hog;
-			gpios = <1 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~pushbutton2-en";
+			gpios = <1 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "pushbutton2-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		pushbutton1 {
 			gpio-hog;
-			gpios = <2 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~pushbutton1-en";
+			gpios = <2 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "pushbutton1-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		leds {
 			gpio-hog;
-			gpios = <3 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~leds-en";
+			gpios = <3 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "leds-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		flg0 {
 			gpio-hog;
-			gpios = <4 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~flg0_loop";
+			gpios = <4 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "flg0_loop";
 			u-boot,dm-pre-reloc;
 		};
 
 		flg1 {
 			gpio-hog;
-			gpios = <5 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~flg1_loop";
+			gpios = <5 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "flg1_loop";
 			u-boot,dm-pre-reloc;
 		};
 
 		flg2 {
 			gpio-hog;
-			gpios = <6 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~flg2_loop";
+			gpios = <6 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "flg2_loop";
 			u-boot,dm-pre-reloc;
 		};
 
 		flg3 {
 			gpio-hog;
-			gpios = <7 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~flg3_loop";
+			gpios = <7 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "flg3_loop";
 			u-boot,dm-pre-reloc;
 		};
 
 		adau1977 {
 			gpio-hog;
-			gpios = <8 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~adau1977_en";
+			gpios = <8 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "adau1977_en";
 			u-boot,dm-pre-reloc;
 		};
 
 		adau1977_fault_rst {
 			gpio-hog;
-			gpios = <9 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~adau1977_fault_rst_en";
+			gpios = <9 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "adau1977_fault_rst_en";
 			u-boot,dm-pre-reloc;
 		};
 
 		thumbwheel {
 			gpio-hog;
-			gpios = <10 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~thumbwheel_oe";
+			gpios = <10 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "thumbwheel_oe";
 			u-boot,dm-pre-reloc;
 		};
 
 		engine_rpm {
 			gpio-hog;
-			gpios = <11 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~engine_rpm_oe";
+			gpios = <11 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "engine_rpm_oe";
 			u-boot,dm-pre-reloc;
 		};
 	};

--- a/arch/arm/dts/sc589-ezkit.dts
+++ b/arch/arm/dts/sc589-ezkit.dts
@@ -32,41 +32,41 @@
 
 		eeprom {
 			gpio-hog;
-			gpios = <0 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~eeprom-en";
+			gpios = <0 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "eeprom-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		uart0-flow-en {
 			gpio-hog;
-			gpios = <1 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~uart0-flow-en";
+			gpios = <1 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "uart0-flow-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		uart0-en {
 			gpio-hog;
-			gpios = <2 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~uart0-en";
+			gpios = <2 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "uart0-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		eth0 {
 			gpio-hog;
-			gpios = <3 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~eth0-en";
+			gpios = <3 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "eth0-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		eth1 {
 			gpio-hog;
-			gpios = <4 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~eth1-en";
+			gpios = <4 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "eth1-en";
 			u-boot,dm-pre-reloc;
 		};
 
@@ -80,73 +80,73 @@
 
 		can0 {
 			gpio-hog;
-			gpios = <6 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~can0-en";
+			gpios = <6 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "can0-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		can1 {
 			gpio-hog;
-			gpios = <7 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~can1-en";
+			gpios = <7 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "can1-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		adau1962 {
 			gpio-hog;
-			gpios = <8 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~adau1962-en";
+			gpios = <8 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "adau1962-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		adau1979 {
 			gpio-hog;
-			gpios = <9 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~adau1979-en";
+			gpios = <9 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "adau1979-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		sd_wp {
 			gpio-hog;
-			gpios = <11 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~sd-wp-en";
+			gpios = <11 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "sd-wp-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		spi2d2-d3 {
 			gpio-hog;
-			gpios = <12 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~spi2d2-d3-en";
+			gpios = <12 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "spi2d2-d3-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		spi2flash-cs {
 			gpio-hog;
-			gpios = <13 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~spi2flash-cs";
+			gpios = <13 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "spi2flash-cs";
 			u-boot,dm-pre-reloc;
 		};
 
 		spdif-opt {
 			gpio-hog;
-			gpios = <14 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~spdif-optical-en";
+			gpios = <14 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "spdif-optical-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		spdif-dig {
 			gpio-hog;
-			gpios = <15 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~spdif-digital-en";
+			gpios = <15 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "spdif-digital-en";
 			u-boot,dm-pre-reloc;
 		};
 	};
@@ -160,41 +160,41 @@
 
 		pushbutton1 {
 			gpio-hog;
-			gpios = <0 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~pushbutton1-en";
+			gpios = <0 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "pushbutton1-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		pushbutton2 {
 			gpio-hog;
-			gpios = <1 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~pushbutton2-en";
+			gpios = <1 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "pushbutton2-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		led10 {
 			gpio-hog;
-			gpios = <2 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~led10-en";
+			gpios = <2 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "led10-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		led11 {
 			gpio-hog;
-			gpios = <3 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~led11-en";
+			gpios = <3 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "led11-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		led12 {
 			gpio-hog;
-			gpios = <4 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~led12-en";
+			gpios = <4 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "led12-en";
 			u-boot,dm-pre-reloc;
 		};
 	};

--- a/arch/arm/dts/sc594-som-ezkit.dts
+++ b/arch/arm/dts/sc594-som-ezkit.dts
@@ -43,32 +43,32 @@
 
 		microsd {
 			gpio-hog;
-			gpios = <2 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~microsd-spi";
+			gpios = <2 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "microsd-spi";
 			u-boot,dm-pre-reloc;
 		};
 
 		adau-reset {
 			gpio-hog;
-			gpios = <5 GPIO_ACTIVE_HIGH>;
-			output-high;
+			gpios = <5 GPIO_ACTIVE_LOW>;
+			output-low;
 			line-name = "adau-reset";
 			u-boot,dm-pre-reloc;
 		};
 
 		adau1962 {
 			gpio-hog;
-			gpios = <6 GPIO_ACTIVE_HIGH>;
-			output-low;
+			gpios = <6 GPIO_ACTIVE_LOW>;
+			output-high;
 			line-name = "adau1962-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		adau1979 {
 			gpio-hog;
-			gpios = <7 GPIO_ACTIVE_HIGH>;
-			output-low;
+			gpios = <7 GPIO_ACTIVE_LOW>;
+			output-high;
 			line-name = "adau1979-en";
 			u-boot,dm-pre-reloc;
 		};
@@ -83,16 +83,16 @@
 
 		spdif-dig {
 			gpio-hog;
-			gpios = <9 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~spdif-digital-en";
+			gpios = <9 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "spdif-digital-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		spdif-opt {
 			gpio-hog;
-			gpios = <10 GPIO_ACTIVE_HIGH>;
-			output-high;
+			gpios = <10 GPIO_ACTIVE_LOW>;
+			output-low;
 			line-name = "~spdif-optical-en";
 			u-boot,dm-pre-reloc;
 		};
@@ -115,21 +115,21 @@
 
 		eth1 {
 			gpio-hog;
-			gpios = <13 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~eth1-en";
+			gpios = <13 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "eth1-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		eth1-reset {
 			gpio-hog;
-			gpios = <14 GPIO_ACTIVE_HIGH>;
+			gpios = <14 GPIO_ACTIVE_LOW>;
 			/*
 			 * USB0 lines are shared with Eth1 so  Eth PHY must be held in reset
 			 * when using the USB
 			 */
-			output-low;
-			line-name = "~eth1-reset";
+			output-high;
+			line-name = "eth1-reset";
 			u-boot,dm-pre-reloc;
 		};
 
@@ -137,7 +137,7 @@
 			gpio-hog;
 			gpios = <15 GPIO_ACTIVE_HIGH>;
 			output-high;
-			line-name = "~gige-reset";
+			line-name = "gige-reset";
 			u-boot,dm-pre-reloc;
 		};
 	};

--- a/arch/arm/dts/sc594-som-ezlite.dts
+++ b/arch/arm/dts/sc594-som-ezlite.dts
@@ -27,72 +27,72 @@
 
 		usb-spi0 {
 			gpio-hog;
-			gpios = <8 GPIO_ACTIVE_HIGH>;
-			output-high;
+			gpios = <8 GPIO_ACTIVE_LOW>;
+			output-low;
 			line-name = "usb_spi0_en";
 			u-boot,dm-pre-reloc;
 		};
 
 		usb-spi1 {
 			gpio-hog;
-			gpios = <9 GPIO_ACTIVE_HIGH>;
-			output-high;
+			gpios = <9 GPIO_ACTIVE_LOW>;
+			output-low;
 			line-name = "usb_spi1_en";
 			u-boot,dm-pre-reloc;
 		};
 
 		usb-qspi-en {
 			gpio-hog;
-			gpios = <10 GPIO_ACTIVE_HIGH>;
-			output-high;
+			gpios = <10 GPIO_ACTIVE_LOW>;
+			output-low;
 			line-name = "usb_qspi_en";
 			u-boot,dm-pre-reloc;
 		};
 
 		usb-qspi-reset {
 			gpio-hog;
-			gpios = <11 GPIO_ACTIVE_HIGH>;
-			output-low;
+			gpios = <11 GPIO_ACTIVE_LOW>;
+			output-high;
 			line-name = "usb_qspi_reset";
 			u-boot,dm-pre-reloc;
 		};
 
 		eth0-reset {
 			gpio-hog;
-			gpios = <12 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~eth0-reset";
+			gpios = <12 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "eth0-reset";
 			u-boot,dm-pre-reloc;
 		};
 
 		adau1372-pwrdwn {
 			gpio-hog;
-			gpios = <13 GPIO_ACTIVE_HIGH>;
-			output-low;
+			gpios = <13 GPIO_ACTIVE_LOW>;
+			output-high;
 			line-name = "adau1372_pwrdwn";
 			u-boot,dm-pre-reloc;
 		};
 
 		led1 {
 			gpio-hog;
-			gpios = <15 GPIO_ACTIVE_HIGH>;
-			output-low;
+			gpios = <15 GPIO_ACTIVE_LOW>;
+			output-high;
 			line-name = "led1-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		led2 {
 			gpio-hog;
-			gpios = <16 GPIO_ACTIVE_HIGH>;
-			output-low;
+			gpios = <16 GPIO_ACTIVE_LOW>;
+			output-high;
 			line-name = "led2-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		led3 {
 			gpio-hog;
-			gpios = <17 GPIO_ACTIVE_HIGH>;
-			output-low;
+			gpios = <17 GPIO_ACTIVE_LOW>;
+			output-high;
 			line-name = "led3-en";
 			u-boot,dm-pre-reloc;
 		};

--- a/arch/arm/dts/sc594-som.dtsi
+++ b/arch/arm/dts/sc594-som.dtsi
@@ -107,41 +107,41 @@
 
 		spi2flash-cs {
 			gpio-hog;
-			gpios = <3 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~spi2flash-cs";
+			gpios = <3 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "spi2flash-cs";
 			u-boot,dm-pre-reloc;
 		};
 
 		spi2d2-d3 {
 			gpio-hog;
-			gpios = <4 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~spi2d2-d3-en";
+			gpios = <4 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "spi2d2-d3-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		uart0 {
 			gpio-hog;
-			gpios = <5 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~uart0-en";
+			gpios = <5 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "uart0-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		uart0-flow-en {
 			gpio-hog;
-			gpios = <6 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~uart0-flow-en";
+			gpios = <6 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "uart0-flow-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		ospiflash-cs {
 			gpio-hog;
-			gpios = <7 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~ospiflash-cs";
+			gpios = <7 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "ospiflash-cs";
 			u-boot,dm-pre-reloc;
 		};
 	};

--- a/arch/arm/dts/sc598-som-ezkit.dts
+++ b/arch/arm/dts/sc598-som-ezkit.dts
@@ -43,40 +43,40 @@
 
 		microsd {
 			gpio-hog;
-			gpios = <2 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~microsd-spi";
+			gpios = <2 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "microsd-spi";
 			u-boot,dm-pre-reloc;
 		};
 
 		ftdi {
 			gpio-hog;
-			gpios = <3 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~ftdi-usb-en";
+			gpios = <3 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "ftdi-usb-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		can {
 			gpio-hog;
-			gpios = <4 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~can-en";
+			gpios = <4 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "can-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		adau1962 {
 			gpio-hog;
-			gpios = <6 GPIO_ACTIVE_HIGH>;
-			output-low;
+			gpios = <6 GPIO_ACTIVE_LOW>;
+			output-high;
 			line-name = "adau1962-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		adau1979 {
 			gpio-hog;
-			gpios = <7 GPIO_ACTIVE_HIGH>;
-			output-low;
+			gpios = <7 GPIO_ACTIVE_LOW>;
+			output-high;
 			line-name = "adau1979-en";
 			u-boot,dm-pre-reloc;
 		};
@@ -91,17 +91,17 @@
 
 		spdif-dig {
 			gpio-hog;
-			gpios = <9 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~spdif-digital-en";
+			gpios = <9 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "spdif-digital-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		spdif-opt {
 			gpio-hog;
-			gpios = <10 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~spdif-optical-en";
+			gpios = <10 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "spdif-optical-en";
 			u-boot,dm-pre-reloc;
 		};
 
@@ -123,21 +123,21 @@
 
 		eth1 {
 			gpio-hog;
-			gpios = <13 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~eth1-en";
+			gpios = <13 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "eth1-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		eth1-reset {
 			gpio-hog;
-			gpios = <14 GPIO_ACTIVE_HIGH>;
+			gpios = <14 GPIO_ACTIVE_LOW>;
 			/*
 			 * USB0 lines are shared with Eth1 so  Eth PHY must be held in reset
 			 * when using the USB
 			 */
-			output-low;
-			line-name = "~eth1-reset";
+			output-high;
+			line-name = "eth1-reset";
 			u-boot,dm-pre-reloc;
 		};
 
@@ -145,7 +145,7 @@
 			gpio-hog;
 			gpios = <15 GPIO_ACTIVE_HIGH>;
 			output-high;
-			line-name = "~gige-reset";
+			line-name = "gige-reset";
 			u-boot,dm-pre-reloc;
 		};
 	};

--- a/arch/arm/dts/sc598-som-ezlite.dts
+++ b/arch/arm/dts/sc598-som-ezlite.dts
@@ -27,72 +27,72 @@
 
 		usb-spi0 {
 			gpio-hog;
-			gpios = <8 GPIO_ACTIVE_HIGH>;
-			output-high;
+			gpios = <8 GPIO_ACTIVE_LOW>;
+			output-low;
 			line-name = "usb_spi0_en";
 			u-boot,dm-pre-reloc;
 		};
 
 		usb-spi1 {
 			gpio-hog;
-			gpios = <9 GPIO_ACTIVE_HIGH>;
-			output-high;
+			gpios = <9 GPIO_ACTIVE_LOW>;
+			output-low;
 			line-name = "usb_spi1_en";
 			u-boot,dm-pre-reloc;
 		};
 
 		usb-qspi-en {
 			gpio-hog;
-			gpios = <10 GPIO_ACTIVE_HIGH>;
-			output-high;
+			gpios = <10 GPIO_ACTIVE_LOW>;
+			output-low;
 			line-name = "usb_qspi_en";
 			u-boot,dm-pre-reloc;
 		};
 
 		usb-qspi-reset {
 			gpio-hog;
-			gpios = <11 GPIO_ACTIVE_HIGH>;
-			output-low;
+			gpios = <11 GPIO_ACTIVE_LOW>;
+			output-high;
 			line-name = "usb_qspi_reset";
 			u-boot,dm-pre-reloc;
 		};
 
 		eth0-reset {
 			gpio-hog;
-			gpios = <12 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~eth0-reset";
+			gpios = <12 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "eth0-reset";
 			u-boot,dm-pre-reloc;
 		};
 
 		adau1372-pwrdwn {
 			gpio-hog;
-			gpios = <13 GPIO_ACTIVE_HIGH>;
-			output-low;
+			gpios = <13 GPIO_ACTIVE_LOW>;
+			output-high;
 			line-name = "adau1372_pwrdwn";
 			u-boot,dm-pre-reloc;
 		};
 
 		led1 {
 			gpio-hog;
-			gpios = <15 GPIO_ACTIVE_HIGH>;
-			output-low;
+			gpios = <15 GPIO_ACTIVE_LOW>;
+			output-high;
 			line-name = "led1-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		led2 {
 			gpio-hog;
-			gpios = <16 GPIO_ACTIVE_HIGH>;
-			output-low;
+			gpios = <16 GPIO_ACTIVE_LOW>;
+			output-high;
 			line-name = "led2-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		led3 {
 			gpio-hog;
-			gpios = <17 GPIO_ACTIVE_HIGH>;
-			output-low;
+			gpios = <17 GPIO_ACTIVE_LOW>;
+			output-high;
 			line-name = "led3-en";
 			u-boot,dm-pre-reloc;
 		};

--- a/arch/arm/dts/sc598-som.dtsi
+++ b/arch/arm/dts/sc598-som.dtsi
@@ -164,48 +164,48 @@
 
 		spi2d2-d3 {
 			gpio-hog;
-			gpios = <3 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~spi2d2-d3-en";
+			gpios = <3 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "spi2d2-d3-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		spi2flash-cs {
 			gpio-hog;
-			gpios = <4 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~spi2flash-cs";
+			gpios = <4 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "spi2flash-cs";
 			u-boot,dm-pre-reloc;
 		};
 
 		uart0 {
 			gpio-hog;
-			gpios = <5 GPIO_ACTIVE_HIGH>;
-			output-low;
-			line-name = "~uart0-en";
+			gpios = <5 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "uart0-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		uart0-flow-en {
 			gpio-hog;
-			gpios = <6 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "~uart0-flow-en";
+			gpios = <6 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "uart0-flow-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		emmc {
 			gpio-hog;
-			gpios = <8 GPIO_ACTIVE_HIGH>;
-			output-low;
+			gpios = <8 GPIO_ACTIVE_LOW>;
+			output-high;
 			line-name = "emmc-en";
 			u-boot,dm-pre-reloc;
 		};
 
 		emmc-som-en {
 			gpio-hog;
-			gpios = <9 GPIO_ACTIVE_HIGH>;
-			output-high;
+			gpios = <9 GPIO_ACTIVE_LOW>;
+			output-low;
 			line-name = "emmc-som-en";
 			u-boot,dm-pre-reloc;
 		};

--- a/arch/arm/mach-sc5xx/sc59x/sc59x-shared.c
+++ b/arch/arm/mach-sc5xx/sc59x/sc59x-shared.c
@@ -31,15 +31,15 @@ int adi_enable_ethernet_softconfig(void)
 	struct gpio_desc *gige_reset;
 
 #if defined(CONFIG_ADI_CARRIER_SOMCRR_EZKIT)
-	gpio_hog_lookup_name("~eth1-en", &eth1);
-	gpio_hog_lookup_name("~eth1-reset", &eth1_reset);
-	gpio_hog_lookup_name("~gige-reset", &gige_reset);
+	gpio_hog_lookup_name("eth1-en", &eth1);
+	gpio_hog_lookup_name("eth1-reset", &eth1_reset);
+	gpio_hog_lookup_name("gige-reset", &gige_reset);
 
 	dm_gpio_set_value(eth1, 1);
 	dm_gpio_set_value(eth1_reset, 0);
 	dm_gpio_set_value(gige_reset, 1);
 #elif defined(CONFIG_ADI_CARRIER_SOMCRR_EZLITE)
-	gpio_hog_lookup_name("~eth0-reset", &gige_reset);
+	gpio_hog_lookup_name("eth0-reset", &gige_reset);
 	dm_gpio_set_value(gige_reset, 1);
 #endif
 
@@ -53,15 +53,15 @@ int adi_disable_ethernet_softconfig(void)
 	struct gpio_desc *gige_reset;
 
 #if defined(CONFIG_ADI_CARRIER_SOMCRR_EZKIT)
-	gpio_hog_lookup_name("~eth1-en", &eth1);
-	gpio_hog_lookup_name("~eth1-reset", &eth1_reset);
-	gpio_hog_lookup_name("~gige-reset", &gige_reset);
+	gpio_hog_lookup_name("eth1-en", &eth1);
+	gpio_hog_lookup_name("eth1-reset", &eth1_reset);
+	gpio_hog_lookup_name("gige-reset", &gige_reset);
 
 	dm_gpio_set_value(eth1, 1);
 	dm_gpio_set_value(eth1_reset, 0);
 	dm_gpio_set_value(gige_reset, 0);
 #elif defined(CONFIG_ADI_CARRIER_SOMCRR_EZLITE)
-	gpio_hog_lookup_name("~eth0-reset", &gige_reset);
+	gpio_hog_lookup_name("eth0-reset", &gige_reset);
 	dm_gpio_set_value(gige_reset, 0);
 #endif
 

--- a/board/adi/common-sc598-som/sc598-som-dynamic-qspi-ospi-uart-mux.c
+++ b/board/adi/common-sc598-som/sc598-som-dynamic-qspi-ospi-uart-mux.c
@@ -89,11 +89,11 @@ int adi_enable_ospi(void)
 	struct gpio_desc *spi2flash_cs;
 	struct gpio_desc *spi2d2_d3;
 
-	gpio_hog_lookup_name("~ftdi-usb-en", &ftdi);
+	gpio_hog_lookup_name("ftdi-usb-en", &ftdi);
 	gpio_hog_lookup_name("octal-spi-cs-en", &octal);
-	gpio_hog_lookup_name("~uart0-en", &uart0);
-	gpio_hog_lookup_name("~spi2flash-cs", &spi2flash_cs);
-	gpio_hog_lookup_name("~spi2d2-d3-en", &spi2d2_d3);
+	gpio_hog_lookup_name("uart0-en", &uart0);
+	gpio_hog_lookup_name("spi2flash-cs", &spi2flash_cs);
+	gpio_hog_lookup_name("spi2d2-d3-en", &spi2d2_d3);
 
 	if (CONFIG_UART_CONSOLE != 0)
 		return 0;
@@ -132,11 +132,11 @@ int adi_disable_ospi(bool changeMuxImmediately)
 	struct gpio_desc *spi2flash_cs;
 	struct gpio_desc *spi2d2_d3;
 
-	gpio_hog_lookup_name("~ftdi-usb-en", &ftdi);
+	gpio_hog_lookup_name("ftdi-usb-en", &ftdi);
 	gpio_hog_lookup_name("octal-spi-cs-en", &octal);
-	gpio_hog_lookup_name("~uart0-en", &uart0);
-	gpio_hog_lookup_name("~spi2flash-cs", &spi2flash_cs);
-	gpio_hog_lookup_name("~spi2d2-d3-en", &spi2d2_d3);
+	gpio_hog_lookup_name("uart0-en", &uart0);
+	gpio_hog_lookup_name("spi2flash-cs", &spi2flash_cs);
+	gpio_hog_lookup_name("spi2d2-d3-en", &spi2d2_d3);
 
 	if (CONFIG_UART_CONSOLE != 0)
 		return 0;


### PR DESCRIPTION
Active low signals on the sc5xx family were configured as active high because of an incorrect assumption about the meaning of the output-low/high attributes. This commit corrects the physical signal levels while updating the logical levels accordingly for a transparent alteration.

This is a copy of the changes in : https://github.com/analogdevicesinc/u-boot/pull/22 until Yocto switches to that repo
