### PR TITLE
board: adi: sc5xx: Fix GPIO writes for softconfig

### DIFF
--- a/arch/arm/dts/sc59x.dtsi
+++ b/arch/arm/dts/sc59x.dtsi
@@ -60,6 +60,7 @@
 			phy-names = "usb2-phy";
 			pinctrl-names = "default";
 			pinctrl-0 = <&usb0_default>;
+			hnp-srp-disable;
 			status = "disabled";
 		};
 	};

--- a/arch/arm/mach-sc5xx/sc59x/sc59x-shared.c
+++ b/arch/arm/mach-sc5xx/sc59x/sc59x-shared.c
@@ -36,7 +36,7 @@ int adi_enable_ethernet_softconfig(void)
 	gpio_hog_lookup_name("gige-reset", &gige_reset);
 
 	dm_gpio_set_value(eth1, 1);
-	dm_gpio_set_value(eth1_reset, 0);
+	dm_gpio_set_value(eth1_reset, 1);
 	dm_gpio_set_value(gige_reset, 1);
 #elif defined(CONFIG_ADI_CARRIER_SOMCRR_EZLITE)
 	gpio_hog_lookup_name("eth0-reset", &gige_reset);
@@ -58,7 +58,7 @@ int adi_disable_ethernet_softconfig(void)
 	gpio_hog_lookup_name("gige-reset", &gige_reset);
 
 	dm_gpio_set_value(eth1, 1);
-	dm_gpio_set_value(eth1_reset, 0);
+	dm_gpio_set_value(eth1_reset, 1);
 	dm_gpio_set_value(gige_reset, 0);
 #elif defined(CONFIG_ADI_CARRIER_SOMCRR_EZLITE)
 	gpio_hog_lookup_name("eth0-reset", &gige_reset);

--- a/board/adi/common-sc598-som/sc598-som-dynamic-qspi-ospi-uart-mux.c
+++ b/board/adi/common-sc598-som/sc598-som-dynamic-qspi-ospi-uart-mux.c
@@ -110,11 +110,11 @@ int adi_enable_ospi(void)
 		//PortA on Address 22 -- Disable the FTDI
 		//PortB on Address 22 -- Enable Octal SPI CS
 		//PortA on Address 20 -- Disable UART0, SPI2D2_D3, SPI2FLASH_CS
-		dm_gpio_set_value(ftdi, 1);
+		dm_gpio_set_value(ftdi, 0);
 		dm_gpio_set_value(octal, 1);
-		dm_gpio_set_value(uart0, 1);
-		dm_gpio_set_value(spi2flash_cs, 1);
-		dm_gpio_set_value(spi2d2_d3, 1);
+		dm_gpio_set_value(uart0, 0);
+		dm_gpio_set_value(spi2flash_cs, 0);
+		dm_gpio_set_value(spi2d2_d3, 0);
 
 		enable_ospi_mux();
 	}
@@ -155,11 +155,11 @@ int adi_disable_ospi(bool changeMuxImmediately)
 		//PortA on Address 22 -- Enable the FTDI
 		//PortB on Address 22 -- Disable Octal SPI CS
 		//PortA on Address 20 -- Enable UART0, SPI2D2_D3, SPI2FLASH_CS
-		dm_gpio_set_value(ftdi, 0);
+		dm_gpio_set_value(ftdi, 1);
 		dm_gpio_set_value(octal, 0);
-		dm_gpio_set_value(uart0, 0);
-		dm_gpio_set_value(spi2flash_cs, 0);
-		dm_gpio_set_value(spi2d2_d3, 0);
+		dm_gpio_set_value(uart0, 1);
+		dm_gpio_set_value(spi2flash_cs, 1);
+		dm_gpio_set_value(spi2d2_d3, 1);
 
 		uartEnabled = 1;
 	}

--- a/common/usb_hub.c
+++ b/common/usb_hub.c
@@ -240,7 +240,7 @@ static struct usb_hub_device *usb_hub_allocate(void)
 }
 #endif
 
-#define MAX_TRIES 5
+#define MAX_TRIES 10
 
 static inline const char *portspeed(int portstatus)
 {
@@ -367,9 +367,15 @@ int usb_hub_port_connect_change(struct usb_device *dev, int port)
 	     (!(portstatus & USB_PORT_STAT_ENABLE))) ||
 	    usb_device_has_child_on_port(dev, port)) {
 		debug("usb_disconnect(&hub->children[port]);\n");
-		/* Return now if nothing is connected */
-		if (!(portstatus & USB_PORT_STAT_CONNECTION))
+
+		/* Check for stuck reset condition. If a device shows no device connection
+		*  but is still reporting a reset, let the reset sequence below catch if a
+		* device is actually connected.
+		*/
+		if (!(portstatus & USB_PORT_STAT_RESET) &&
+		    !(portstatus & USB_PORT_STAT_CONNECTION)) {
 			return -ENOTCONN;
+		}
 	}
 
 	/* Reset the port */


### PR DESCRIPTION
With the old polarities, the values given to the GPIO write functions in the softconfig were given as if they were active low, while the GPIOs were declared active high. When the polarities were corrected, because the function already accounts for the polarity, the values given to the functions were now opposite of what was needed.
